### PR TITLE
Bug with wildcard detection

### DIFF
--- a/app/code/community/Optimiseweb/Redirects/Model/Redirector.php
+++ b/app/code/community/Optimiseweb/Redirects/Model/Redirector.php
@@ -197,9 +197,9 @@ class Optimiseweb_Redirects_Model_Redirector
 
                         if ($sourceUrl == $requestUrl) {
                             $doRedirect = TRUE;
-                        } elseif (strpos($sourceUrl, Mage::getStoreConfig('optimisewebredirects/querystring/wildcardcharacter'))) {
+                        } elseif (strpos($sourceUrl, Mage::getStoreConfig('optimisewebredirects/querystring/wildcardcharacter')) !== false) {
                             $sourceUrl = str_replace(Mage::getStoreConfig('optimisewebredirects/querystring/wildcardcharacter'), '', $sourceUrl);
-                            if (strpos($requestUrl, $sourceUrl) === 0) {
+                            if (strpos($requestUrl, $sourceUrl) !== false) {
                                 $doRedirect = TRUE;
                             }
                         }


### PR DESCRIPTION
The `strpos` function would return 0 for the wild card at the start, which means that the else if would never run. Also allowed for url detection inside the url, not just from the start.